### PR TITLE
Fix content-type and send ping after socket is open

### DIFF
--- a/src/queue.ts
+++ b/src/queue.ts
@@ -8,7 +8,7 @@ import {
   ListenPerform,
   QueueJob,
 } from "./types.ts";
-import { listen } from "./ws-event-generator.ts";
+import { messagesStream } from "./ws-event-generator.ts";
 
 export class JetQueue {
   private pluginInstance: BreezeRuntime.Plugin;
@@ -171,11 +171,17 @@ export class JetQueue {
     function ack(message: AckMessage) {
       socket.send(JSON.stringify(message));
     }
+
     for await (
-      const jobs of chunk(
-        this.listenQueueJobs(socket),
-        options.batchSize,
-        100,
+      const jobs of messagesStream<QueueJob>(
+        socket,
+        {
+          timeout: 1_000,
+          batchSize: options.batchSize,
+          batchTimeout: 100,
+          dataBuilder: (event: MessageEvent<string>) =>
+            this.parseMessageData(event.data),
+        },
       )
     ) {
       await perform(jobs, { ack });
@@ -195,81 +201,8 @@ export class JetQueue {
     return new WebSocket(endpoint);
   }
 
-  private async *listenQueueJobs(socket: WebSocket): AsyncIterable<QueueJob> {
-    let pong = true;
-
-    socket.addEventListener("open", () => {
-      (function ping() {
-        if (pong) {
-          pong = false;
-          socket.send("ping");
-          setTimeout(ping, 1_000);
-        } else {
-          throw new Error("Ping timeout");
-        }
-      })();
-    });
-
-    for await (const { data } of listen<string>(socket)) {
-      const message = this.parseMessageData(data);
-
-      if ("pong" === message) {
-        pong = true;
-      } else {
-        yield* message.payload;
-      }
-    }
-  }
-
-  private parseMessageData(data: string): "pong" | JobsMessage {
-    if ("pong" === data) {
-      return data;
-    } else {
-      return JSON.parse(data);
-    }
-  }
-}
-
-async function* chunk<T>(
-  iterable: AsyncIterable<T>,
-  size: number,
-  timeout: number,
-): AsyncIterable<Array<T>> {
-  const iterator = iterable[Symbol.asyncIterator]();
-  const buffer: Array<T> = [];
-
-  async function takeSize(): Promise<Array<T>> {
-    while (buffer.length < size) {
-      const result = await Promise.race([
-        new Promise<void>((resolve) => setTimeout(resolve, timeout)),
-        iterator.next().then((elem) => {
-          buffer.push(elem.value);
-          return elem;
-        }),
-      ]);
-
-      // 超时了
-      if (!result) break;
-
-      if (buffer.length === size) {
-        break;
-      }
-    }
-
-    return transfer<T>(buffer, Math.min(buffer.length, size));
-  }
-
-  function transfer<K>(arr: Array<K>, size: number): Array<K> {
-    const result: Array<K> = [];
-
-    for (let i = 0; i < size; i++) {
-      result.push(arr.shift()!);
-    }
-
-    return result;
-  }
-
-  while (true) {
-    yield takeSize();
+  private parseMessageData(data: string): Array<QueueJob> {
+    const message: JobsMessage = JSON.parse(data);
+    return message.payload;
   }
 }

--- a/src/ws-event-generator.ts
+++ b/src/ws-event-generator.ts
@@ -16,12 +16,12 @@ export async function* listen<E>(
   socket.addEventListener("message", pushEvent);
 
   while (true) {
-    if (0 === buffer.length) {
-      await new Promise<MessageEvent<E>>((resolve) => {
+    yield await new Promise<MessageEvent<E>>((resolve) => {
+      if (0 === buffer.length) {
         waitList.push(resolve);
-      });
-    } else {
-      yield buffer.shift()!;
-    }
+      } else {
+        resolve(buffer.shift()!);
+      }
+    });
   }
 }

--- a/src/ws-event-generator.ts
+++ b/src/ws-event-generator.ts
@@ -1,27 +1,75 @@
-export async function* listen<E>(
-  socket: WebSocket,
-): AsyncIterable<MessageEvent<E>> {
-  const waitList: Array<(event: MessageEvent<E>) => void> = [];
-  const buffer: Array<MessageEvent<E>> = [];
+export interface MessagesStreamOptions<T> {
+  timeout: number;
+  batchSize: number;
+  batchTimeout: number;
+  dataBuilder: (event: MessageEvent<string>) => Array<T>;
+}
 
-  function pushEvent(event: MessageEvent<E>) {
-    if (0 === waitList.length) {
-      buffer.push(event);
-    } else {
-      const resolver = waitList.shift()!;
-      resolver(event);
+export async function* messagesStream<T>(
+  socket: WebSocket,
+  options: MessagesStreamOptions<T>,
+): AsyncIterable<Array<T>> {
+  const { timeout, batchSize, batchTimeout, dataBuilder } = options;
+
+  const buffer: Array<T> = [];
+
+  let pong = true;
+
+  let beginResolver: (() => void) | undefined = undefined;
+  let commitResolver: (() => void) | undefined = undefined;
+
+  function pushEvent(event: MessageEvent<string>) {
+    if (beginResolver) {
+      beginResolver();
+    }
+
+    buffer.push(...dataBuilder(event));
+
+    if (commitResolver && buffer.length >= batchSize) {
+      commitResolver();
     }
   }
 
-  socket.addEventListener("message", pushEvent);
+  socket.addEventListener("open", () => {
+    (function ping() {
+      if (pong) {
+        pong = false;
+        socket.send("ping");
+        setTimeout(ping, timeout);
+      } else {
+        throw new Error("Ping timeout");
+      }
+    })();
+  });
+
+  socket.addEventListener("message", (event: MessageEvent<string>) => {
+    if ("pong" === event.data) {
+      pong = true;
+    } else {
+      pushEvent(event);
+    }
+  });
 
   while (true) {
-    yield await new Promise<MessageEvent<E>>((resolve) => {
-      if (0 === buffer.length) {
-        waitList.push(resolve);
-      } else {
-        resolve(buffer.shift()!);
-      }
+    const commit = new Promise<void>((resolve) => {
+      commitResolver = resolve;
     });
+
+    await new Promise<void>((resolve) => {
+      beginResolver = resolve;
+    });
+
+    beginResolver = undefined;
+
+    await Promise.race([
+      new Promise<void>((resolve) => setTimeout(resolve, batchTimeout)),
+      commit,
+    ]);
+
+    commitResolver = undefined;
+
+    if (0 !== buffer.length) {
+      yield buffer.splice(0, Math.min(buffer.length, batchSize));
+    }
   }
 }


### PR DESCRIPTION
## 修正的问题
1. post 时带上了 content-type
2. 获得正确的 websocket 地址
3. 不处理 websocket 地址的 scheme
4. 当 websocket 连接变为 open 之后才开始 ping
5. 修复了 ws-event-generator

------

chunk 的逻辑仍然是不正确的：
1. 它现在是每取 1 个事件就有 100ms 的超时时间，咱们想要的效果是每取 1 组（batchSize 个）事件有 100ms 的超时时间
2. 现在即使 buffer 里面没有任何事件，只要超过 100ms，它就会 yield 一个空数组 [] 出去

建了一个[任务](https://www.notion.so/byzanteam/chunk-312773e5d0f64b8299edc24bff86fc5b)，专门处理一下，这个 PR 暂不处理