### PR TITLE
feat: export ./testing subpath for npm consumers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@byzanteam/jet-queue-plugin-js",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@byzanteam/jet-queue-plugin-js",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@byzanteam/breeze-js": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,19 @@
 {
   "name": "@byzanteam/jet-queue-plugin-js",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "scripts": {
     "build": "rollup -c rollup.config.mjs",
     "prepare": "npm run build"
   },
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "default": "./dist/testing.js"
+    }
   },
   "types": "./dist/index.d.ts",
   "files": [

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,30 +2,36 @@ import { defineConfig } from "rollup";
 import typescript from "@rollup/plugin-typescript";
 import { dts } from "rollup-plugin-dts";
 
+const tsPlugin = typescript({
+  module: "esnext",
+  moduleResolution: "bundler",
+  strict: true,
+  target: "esnext",
+});
+
 export default defineConfig([
   {
-    input: "src/index.ts",
+    input: ["src/index.ts", "src/testing.ts"],
     output: {
       dir: "dist",
       format: "esm",
     },
-    plugins: [
-      typescript({
-        module: "esnext",
-        moduleResolution: "bundler",
-        strict: true,
-        target: "esnext",
-      }),
-    ],
+    plugins: [tsPlugin],
   },
   {
     input: "src/index.ts",
     output: {
-      dir: "dist",
+      file: "dist/index.d.ts",
       format: "esm",
     },
-    plugins: [
-      dts(),
-    ],
+    plugins: [dts()],
+  },
+  {
+    input: "src/testing.ts",
+    output: {
+      file: "dist/testing.d.ts",
+      format: "esm",
+    },
+    plugins: [dts()],
   },
 ]);


### PR DESCRIPTION
## Summary
- npm package previously exposed only the `.` entry, so consumers importing `setupQueue` / `QueueInternals` via the `/testing` subpath could not resolve it (it lived only in unbuilt `src/testing.ts`).
- Build `src/testing.ts` into `dist/testing.js` + `dist/testing.d.ts` and add a `./testing` export.
- `src/testing.ts` is pure types + injected test helpers (no `@std/testing` runtime dep), so it bundles cleanly with zero imports.
- Bump to `0.6.1`.

## Changes
- `rollup.config.mjs`: JS build now has both `src/index.ts` + `src/testing.ts` inputs; dts split into two single-input passes so each `.d.ts` is self-contained and flat in `dist/`.
- `package.json`: `exports` adds `./testing` with `types`/`default` conditions; version `0.6.0` -> `0.6.1`.
- `package-lock.json`: version sync (publish.yml runs `npm ci`).

## Test plan
- [x] `npm run build` produces `dist/{index,testing}.{js,d.ts}`, no `dist/src/`, no orphan chunks
- [x] `dist/testing.d.ts` fully inlines `Queue` types, `dist/testing.js` has zero imports
- [x] `deno fmt --check` + `deno lint` clean on changed files
- [ ] Publish workflow runs on release (npm ci -> build -> npm-publish)

Generated with Claude Code